### PR TITLE
Support ordering by number of contributions (order: "count")

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ grunt update-authors:path/to/directory
 
 #### authors.order
 
-Define the list order of the authors. The default ordering is by first
+Define the order of the list of authors. The default ordering is by first
 contribution `{order: "date"}`. An alternative ordering is by number of
 contributions `{order: "count"}`.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ grunt update-authors:path/to/directory
 
 ### Config
 
+#### authors.order
+
+Define the list order of the authors. The default ordering is by first
+contribution `{order: "date"}`. An alternative ordering is by number of
+contributions `{order: "count"}`.
+
+*NOTE: This config value is used for the `update-authors` task as well.*
+
+```js
+grunt.initConfig({
+	authors: {
+		order: "count"
+	}
+});
+```
+
 #### authors.prior
 
 Define a list of authors that contributed prior to the first commit in the repo.

--- a/index.js
+++ b/index.js
@@ -51,9 +51,6 @@ function getOptions( options ) {
 	if ( !orderBy.hasOwnProperty( options.order ) ) {
 		options.order = "date";
 	}
-	if ( !orderBy[ options.order ] ) {
-		throw new Error( "Invalid `order` value `" + options.order + "`" );
-	}
 }
 
 function unique( count ) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require( "fs" );
 var path = require( "path" );
 var spawn = require( "spawnback" );
 
-function unique(count) {
+function unique( count ) {
 	count = count || {};
 	return function( i ) {
 		count[ i ] = count[ i ] ? count[ i ] + 1 : 1;
@@ -19,16 +19,16 @@ var orderBy = {
 	count: function( authors ) {
 		var count = {};
 		return authors
-			.filter(unique(count))
-			.sort(function(a, b) {
-				return count[b] - count[a];
+			.filter( unique( count ) )
+			.sort(function( a, b ) {
+				return count[ b ] - count[ a ];
 			});
 	},
 
 	date: function( authors ) {
 		return authors
 			.reverse()
-			.filter(unique());
+			.filter( unique() );
 	}
 };
 
@@ -63,7 +63,7 @@ function updateAuthors( options, callback ) {
 
 		options.order = orderBy[ options.order ] ? options.order : "date";
 
-		var banner = options.banner || banners[options.order];
+		var banner = options.banner || banners[ options.order ];
 		var dir = options.dir || ".";
 		var filename = path.join( dir, options.filename || "AUTHORS.txt" );
 

--- a/index.js
+++ b/index.js
@@ -58,9 +58,9 @@ function unique( count ) {
 	count = count || {};
 	return function( key ) {
 		if ( !(key in count) ) {
-			count[ i ] = 0;
+			count[ key ] = 0;
 		}
-		count[ i ]++;
+		count[ key ]++;
 		return count[ key ] === 1;
 	};
 }

--- a/index.js
+++ b/index.js
@@ -2,14 +2,6 @@ var fs = require( "fs" );
 var path = require( "path" );
 var spawn = require( "spawnback" );
 
-function unique( count ) {
-	count = count || {};
-	return function( i ) {
-		count[ i ] = count[ i ] ? count[ i ] + 1 : 1;
-		return count[ i ] === 1;
-	};
-}
-
 var banners = {
 	count: "Authors ordered by number of contributions",
 	date: "Authors ordered by first contribution"
@@ -44,7 +36,7 @@ function getAuthors( options, callback ) {
 		}
 
 		var tracked = {};
-		options.order = orderBy[ options.order ] ? options.order : "date";
+		options = getOptions( options );
 
 		var authors = result.trimRight().split( "\n" )
 			.concat( (options.priorAuthors || []).reverse() );
@@ -55,13 +47,33 @@ function getAuthors( options, callback ) {
 	});
 }
 
+function getOptions( options ) {
+	if ( !orderBy.hasOwnProperty( options.order ) ) {
+		options.order = "date";
+	}
+	if ( !orderBy[ options.order ] ) {
+		throw new Error( "Invalid `order` value `" + options.order + "`" );
+	}
+}
+
+function unique( count ) {
+	count = count || {};
+	return function( key ) {
+		if ( !(key in count) ) {
+			count[ i ] = 0;
+		}
+		count[ i ]++;
+		return count[ key ] === 1;
+	};
+}
+
 function updateAuthors( options, callback ) {
 	getAuthors( options, function( error, authors ) {
 		if ( error ) {
 			return callback( error );
 		}
 
-		options.order = orderBy[ options.order ] ? options.order : "date";
+		options = getOptions( options );
 
 		var banner = options.banner || banners[ options.order ];
 		var dir = options.dir || ".";

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function getOptions( options ) {
 	if ( !orderBy.hasOwnProperty( options.order ) ) {
 		options.order = "date";
 	}
+	return options;
 }
 
 function unique( count ) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,18 @@ var fs = require( "fs" );
 var path = require( "path" );
 var spawn = require( "spawnback" );
 
+var orderBy = {
+	date: function(authors) {
+		return authors
+			.reverse()
+			.filter(function( author ) {
+				var first = !tracked[ author ];
+				tracked[ author ] = true;
+				return first;
+			});
+	}
+};
+
 exports.getAuthors = getAuthors;
 exports.updateAuthors = updateAuthors;
 
@@ -14,14 +26,12 @@ function getAuthors( options, callback ) {
 		}
 
 		var tracked = {};
+		options.order = orderBy[order] ? order : "date";
+
 		var authors = result.trimRight().split( "\n" )
-			.concat( (options.priorAuthors || []).reverse() )
-			.reverse()
-			.filter(function( author ) {
-				var first = !tracked[ author ];
-				tracked[ author ] = true;
-				return first;
-			});
+			.concat( (options.priorAuthors || []).reverse() );
+
+		authors = orderBy[options.order](authors);
 
 		callback( null, authors );
 	});

--- a/tasks/git-authors.js
+++ b/tasks/git-authors.js
@@ -9,6 +9,7 @@ function( dir ) {
 
 	gitAuthors.getAuthors({
 		dir: dir || ".",
+		order: grunt.config( "authors.order" ),
 		priorAuthors: grunt.config( "authors.prior" )
 	}, function( error, authors ) {
 		if ( error ) {
@@ -28,6 +29,7 @@ function( dir ) {
 
 	gitAuthors.updateAuthors({
 		dir: dir || ".",
+		order: grunt.config( "authors.order" ),
 		priorAuthors: grunt.config( "authors.prior" )
 	}, function( error, filename ) {
 		if ( error ) {


### PR DESCRIPTION
Hi,

In this change, I add support for a different ordering: by number of contributions (`count`), leaving the default as by first contribution (`date`).

This new ordering tries to mimic the order github uses for displaying a project's contributors in graph: e.g., https://github.com/scottgonzalez/grunt-git-authors/graphs/contributors.