### PR TITLE
Move grunt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     }
   ],
   "dependencies": {
-    "grunt": "~0.4.0",
     "spawnback": "~1.0.0"
   },
   "devDependencies": {
+    "grunt": "~0.4.0",
     "grunt-contrib-jshint": "0.10.0"
   },
   "keywords": [


### PR DESCRIPTION
When installing this plugin it will install `grunt` even though it doesn't directly depend on Grunt. Moving to the `devDependencies` will only install for local development and not when 3rd parties `npm install grunt-git-authors` and avoid the extra unneeded install.

Another option would be to add `"grunt": ">= 0.4.0"` as a peer dependency.

---

This will also avoid an issue that will occur when the next version of Grunt lands:

```
$ npm i gruntjs/grunt
npm WARN unmet dependency /Users/Kyle/Documents/www/jquery/node_modules/grunt-git-authors requires grunt@'~0.4.0' but will load
npm WARN unmet dependency /Users/Kyle/Documents/www/jquery/node_modules/grunt,
npm WARN unmet dependency which is version 0.4.6-0
npm ERR! Darwin 15.3.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "i" "gruntjs/grunt"
npm ERR! node v4.2.6
npm ERR! npm  v2.14.12
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package grunt@0.4.6-0 does not satisfy its siblings' peerDependencies requirements!
```

Thanks!